### PR TITLE
feat: Add build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+algohub-extension-v*.zip
+.DS_Store

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,0 +1,2 @@
+version=$(cat package.json | jq -r '.version')
+zip -r algohub-extension-v$version.zip dist/ manifest.json icon.png

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,2 +1,3 @@
 version=$(cat package.json | jq -r '.version')
+sh build.sh && \
 zip -r algohub-extension-v$version.zip dist/ manifest.json icon.png

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 npx vite build --config vite.config.background.ts &
 npx vite build --config vite.config.boj.ts &
 npx vite build --config vite.config.programmers.ts &
+wait


### PR DESCRIPTION
close #6 

[TS / 번들러 도입](https://github.com/GAMZA-BAT/algohub-extension/pull/5)하면서 이제 업로드 하려면 좀 과정이 달라졌는데요
ts는 어떤 js의 발사대 느낌이라, ts를 컴파일하면 실제 실행되는 js가 나오고, 익스텐션은 이 js를 실행해야 합니다.
그래서 dist 아래있는 실제 컴파일된 js, icon, manifest.json만 가지고 압축하도록 하는 스크립트를 추가합니다.  

그냥 ./build-release.sh 로 실행하면 algohub-extension.zip이 생겨요
윈도우면 git bash에서 해야함