### PR TITLE
Fix: Ensure deployable build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 npx vite build --config vite.config.background.ts &
 npx vite build --config vite.config.boj.ts &
-npx vite build --config vite.config.programmers.ts &
+# npx vite build --config vite.config.programmers.ts &
 wait


### PR DESCRIPTION
programmers 파일 안쓰는데 넣었다고 화낸거같아요 

승환이형,, git bash에다가 jq랑 zip을 깔아야하는데 오늘 설명할 기력이 없어서 다음에,,,,

머지되면 풀땡기고

1. dist 폴더 삭제
2. git bash에서 ./build.sh 실행
3. dist폴더, icon.png, manifest.json 압축해서 제출 ㄱㄱ