### PR TITLE
feat: detect extension installed on algohub page

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
 npx vite build --config vite.config.background.ts &
 npx vite build --config vite.config.boj.ts &
 # npx vite build --config vite.config.programmers.ts &
+npx vite build --config vite.config.algohub.ts &
+npx vite build --config vite.config.index.ts &
 wait

--- a/manifest.json
+++ b/manifest.json
@@ -1,36 +1,45 @@
 {
-    "manifest_version": 3,
-    "name": "algohub",
-    "version": "1.0",
-    "description": "algohub-extension",
-    "permissions": [
-        "storage"
-    ],
-    "host_permissions": [
-      "https://api.algohub.kr/*",
-      "https://www.acmicpc.net/*"
-    ],
-    "background": {
-      "service_worker": "dist/background.js"
-    },
-    "content_scripts": [
-      {
-        "matches": ["https://www.acmicpc.net/*"],
-        "js": ["dist/contentBoj.js"]
-      }
-    ],
-    "action": {
-      "default_icon": {
-        "48": "dist/assets/icon.png"
-      }
-    },
-    "icons": {
-      "48": "dist/assets/icon.png"
-    },
-    "web_accessible_resources": [
+  "manifest_version": 3,
+  "name": "algohub",
+  "version": "1.0",
+  "description": "algohub-extension",
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://api.algohub.kr/*",
+    "https://www.acmicpc.net/*"
+  ],
+  "background": {
+    "service_worker": "dist/background.js"
+  },
+  "content_scripts": [
     {
-      "resources": ["dist/assets/icon.png"],
-      "matches": ["<all_urls>"]
+      "matches": [
+        "https://www.acmicpc.net/*",
+        "https://*algohub.kr/*"
+      ],
+      "js": [
+        "dist/contentBoj.js"
+      ]
+    }
+  ],
+  "action": {
+    "default_icon": {
+      "48": "dist/assets/icon.png"
+    }
+  },
+  "icons": {
+    "48": "dist/assets/icon.png"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "dist/assets/icon.png"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,10 +17,12 @@
     {
       "matches": [
         "https://www.acmicpc.net/*",
-        "https://*algohub.kr/*"
+        "https://*.algohub.kr/*"
       ],
       "js": [
-        "dist/contentBoj.js"
+        "dist/contentBoj.js",
+        "dist/contentAlgohub.js",
+        "dist/index.js"
       ]
     }
   ],

--- a/src/contentAlgohub.ts
+++ b/src/contentAlgohub.ts
@@ -1,0 +1,7 @@
+import { setExtensionInstalled } from './utils/algohub';
+
+const algohubInit = () => {
+  setExtensionInstalled();
+};
+
+export default algohubInit;

--- a/src/contentBoj.ts
+++ b/src/contentBoj.ts
@@ -1,4 +1,3 @@
-import { isAlgohubPage, setIsInstalledToWindow } from './utils/algohub';
 import {
   isNonBlank,
   isStatusPage,
@@ -382,7 +381,7 @@ const sendToAPI = ({
 /****************************************************
  * Entry points
  ****************************************************/
-(() => {
+const bojInit = () => {
   // 제출 페이지
   if (isSubmissionPage()) {
     handleSubmissionPage();
@@ -394,9 +393,6 @@ const sendToAPI = ({
       handleStatusPage();
     });
   }
+};
 
-  // 알고헙 페이지 - 익스텐션 설치 확인용
-  if (isAlgohubPage()) {
-    setIsInstalledToWindow();
-  }
-})();
+export default bojInit;

--- a/src/contentBoj.ts
+++ b/src/contentBoj.ts
@@ -1,3 +1,4 @@
+import { isAlgohubPage, setIsInstalledToWindow } from './utils/algohub';
 import {
   isNonBlank,
   isStatusPage,
@@ -392,5 +393,10 @@ const sendToAPI = ({
     window.addEventListener('load', () => {
       handleStatusPage();
     });
+  }
+
+  // 알고헙 페이지 - 익스텐션 설치 확인용
+  if (isAlgohubPage()) {
+    setIsInstalledToWindow();
   }
 })();

--- a/src/contentProgrammers.ts
+++ b/src/contentProgrammers.ts
@@ -14,7 +14,7 @@ const interceptSubmitButtonClick = (submitButton: HTMLButtonElement): void => {
   });
 };
 
-(() => {
+const programmersInit = () => {
   const viewSolutionGroup = document.querySelector<HTMLButtonElement>(
     '#view-solution-group',
   );
@@ -30,4 +30,6 @@ const interceptSubmitButtonClick = (submitButton: HTMLButtonElement): void => {
   });
 
   interceptSubmitButtonClick(submitButton);
-})();
+};
+
+export default programmersInit;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,22 @@
+import algohubInit from './contentAlgohub';
+import bojInit from './contentBoj';
+import programmersInit from './contentProgrammers';
+
+(() => {
+  const url = window.location.hostname;
+
+  // siteURL: initFn
+  const siteMap: Record<string, () => void> = {
+    algohub: algohubInit,
+    acmicpc: bojInit,
+    programmers: programmersInit,
+  };
+
+  const initFn = Object.entries(siteMap).find(([site]) =>
+    url.includes(site),
+  )?.[1];
+
+  if (initFn) {
+    initFn();
+  }
+})();

--- a/src/utils/algohub.ts
+++ b/src/utils/algohub.ts
@@ -1,0 +1,13 @@
+export function isAlgohubPage(): boolean {
+  return /\/algohub/.test(window.location.href);
+}
+
+export function setIsInstalledToWindow() {
+  window.isExtensionInstalled = true;
+}
+
+declare global {
+  interface Window {
+    isExtensionInstalled: boolean;
+  }
+}

--- a/src/utils/algohub.ts
+++ b/src/utils/algohub.ts
@@ -1,6 +1,7 @@
 export function setExtensionInstalled() {
-  // content_script.js
-  const meta = document.createElement('meta');
-  meta.name = 'extension-installed';
-  document.head.appendChild(meta);
+  if (!document.querySelector('meta[name="extension-installed"]')) {
+    const meta = document.createElement('meta');
+    meta.name = 'extension-installed';
+    document.head.appendChild(meta);
+  }
 }

--- a/src/utils/algohub.ts
+++ b/src/utils/algohub.ts
@@ -1,13 +1,6 @@
-export function isAlgohubPage(): boolean {
-  return /\/algohub/.test(window.location.href);
-}
-
-export function setIsInstalledToWindow() {
-  window.isExtensionInstalled = true;
-}
-
-declare global {
-  interface Window {
-    isExtensionInstalled: boolean;
-  }
+export function setExtensionInstalled() {
+  // content_script.js
+  const meta = document.createElement('meta');
+  meta.name = 'extension-installed';
+  document.head.appendChild(meta);
 }

--- a/vite.config.algohub.ts
+++ b/vite.config.algohub.ts
@@ -1,0 +1,16 @@
+// vite.config.js
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    rollupOptions: {
+      input: {
+        contentAlgohub: 'src/contentAlgohub.ts',
+      },
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+  },
+});

--- a/vite.config.index.ts
+++ b/vite.config.index.ts
@@ -1,0 +1,16 @@
+// vite.config.js
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    rollupOptions: {
+      input: {
+        index: 'src/index.ts',
+      },
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+  },
+});


### PR DESCRIPTION
알고헙 페이지에서 익스텐션 설치를 감지하기 위한 수정입니다.

프로그래머스 사이트도 추가 예정에 있는 것 같아 최종 실행 파일 역할을 할 `index.ts`를 추가했고, 그 외 알고헙 페이지에서 사용할 코드들은 기존 양식에 맞게 작성해봤습니다.

- index.ts
  각 사이트의 `entry points`에 해당하는 함수들을 `init`이라는 이름으로 만들어서 export 하고 `index.ts`에서 `siteMap`에 저장 후 url을 검사하여 해당하는 사이트의 init함수를 호출하는 방식입니다.
- contentAlgohub.ts
  알고헙 페이지에 meta tag를 삽입합니다. 
  알고헙 페이지에서는 DOM load 후 useEffect에서 meta tag와 관련 값들을 체크하여 익스텐션 설치 안내 모달을 표시합니다.